### PR TITLE
Fix notifications dropdown perpetual loading + related fixes

### DIFF
--- a/src/components/notifications/NotificationDropdown.svelte
+++ b/src/components/notifications/NotificationDropdown.svelte
@@ -17,13 +17,24 @@
 	let loading = false;
 	let loadingNotifications = false;
 
-	$: if (isOpen && !loadingNotifications) {
+	// Load once when the dropdown component mounts (component is unmounted when closed)
+	onMount(() => {
 		loadNotificationsAndChats();
-	}
+	});
 
 	async function loadNotificationsAndChats() {
 		// Prevent overlapping loads
 		if (loadingNotifications) return;
+
+		// If no valid user, don't attempt to load and clear loading state
+		if (!userId) {
+			notifications = [];
+			conversations = [];
+			loading = false;
+			loadingNotifications = false;
+			return;
+		}
+
 		loadingNotifications = true;
 		loading = true;
 		try {


### PR DESCRIPTION
This PR addresses a perpetual loading state when opening the notifications dropdown. Key changes:&#10;&#10;- fix(notifications): NotificationDropdown now loads data on mount, prevents overlapping loads, and short-circuits when userId is missing&#10;- refactor(profile): unify email_notifications initialization to a single source of truth in ProfileEditForm.svelte&#10;- fix(auth): properly type JWT expiresIn without unsafe any in src/lib/auth/jwt.ts&#10;- feat(places): typed PlaceDetailsResult, include 'types' in placeDetails, use PlacesNearbyRanking.distance, extract fallbackTextSearch helper&#10;- sec(email): HTML-escape all user-controlled fields in email templates&#10;- sec(chat): verify conversation participant before allowing attachment uploads&#10;&#10;Testing:&#10;- Verified dev server on http://localhost:5173&#10;- Opened bell; dropdown now resolves from loading to items/empty state as expected&#10;&#10;Notes:&#10;- Follow-ups: Consider moving dropdown queries to a server endpoint for consistent RLS and further reducing client round-trips.