### PR TITLE
Fix notifications dropdown perpetual loading

### DIFF
--- a/src/components/notifications/NotificationDropdown.svelte
+++ b/src/components/notifications/NotificationDropdown.svelte
@@ -17,13 +17,24 @@
 	let loading = false;
 	let loadingNotifications = false;
 
-	$: if (isOpen && !loadingNotifications) {
+	// Load once when the dropdown component mounts (component is unmounted when closed)
+	onMount(() => {
 		loadNotificationsAndChats();
-	}
+	});
 
 	async function loadNotificationsAndChats() {
 		// Prevent overlapping loads
 		if (loadingNotifications) return;
+
+		// If no valid user, don't attempt to load and clear loading state
+		if (!userId) {
+			notifications = [];
+			conversations = [];
+			loading = false;
+			loadingNotifications = false;
+			return;
+		}
+
 		loadingNotifications = true;
 		loading = true;
 		try {


### PR DESCRIPTION
Cherry-pick of commit 9843e76b0146d9be84b0973701fda22c8169a058 onto a branch created from origin/main. Fixes: load on mount, overlap guard, and missing userId short-circuit to prevent perpetual loading in NotificationDropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications and chats now preload, reducing delays when opening the dropdown.
  * Correctly clears lists and stops loading when signed out or no account is detected.
  * Prevents duplicate loading and ensures loading indicators reset after errors for more reliable behavior.
* **Refactor**
  * Streamlined the notifications loading flow to improve consistency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->